### PR TITLE
Add link to description text and modify the content so it doesn't get truncated

### DIFF
--- a/projects/seesaw.md
+++ b/projects/seesaw.md
@@ -7,4 +7,4 @@ author: Hiroaki Yamane
 picture: /img/projects/seesaw.jpg
 project-link: http://vimeo.com/94125713
 ---
-“Share” originally means cutting or division. But we are not sharing in that context on the web. To demonstrate "Share" in original context, I built a seesaw toy that everyone can control by tilting a phone — *sharing a single physical object via web*.
+“Share” originally means cutting or division. But we are not sharing in that context on web. To demonstrate the original “Share”, I built <a href='http://vimeo.com/94125713'>a seesaw toy</a> everyone can control by tilting a phone — <i>sharing a single physical object via web</i>.


### PR DESCRIPTION
Sorry for bugging you to merge the small changes.

Seems the `project-link` meta data never get used in the project index template, so I added to the description content.

:)
