### PR TITLE
Post-deadline application changes

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -16,7 +16,7 @@
 		<div class="col-md-2 col-sm-2 col-xs-4">
 		<ul class="list-unstyled">
 				<li><a class="participate" href="/participate/">Participate</a></li>
-				<li><a class="apply" href="/participate/apply/">Apply <span class="label label-warning">Due Jan 27</span></a></li>
+				<li><a class="apply" href="/participate/apply/">Apply</a></li>
 				<li><a class="faq" href="/faq/">FAQ</a></li>
 		</ul>
 		</div>

--- a/participate.md
+++ b/participate.md
@@ -20,9 +20,8 @@ slides:
   - "/static/img/participate/dinner.jpg"
 ---
 
-<div class="alert alert-success" role="alert">
-We are accepting <a href="/participate/apply/">applications</a> through <b>January 27th</b> for a ten week session to be held in New York City from March 16th - May 22nd.
-</div>
+<div class="alert alert-success" role="alert"><p><strong>Applications for our Spring 2015 term were due by January 27th and are now being reviewed. We expect to inform applicants by February 15th.</strong></p>
+<p>If you missed the deadline, we will continue <a href="/participate/apply/">accepting applications</a> on a rolling basis until all slots have been filled.</p></div>
 
 ***
 

--- a/participate/apply.md
+++ b/participate/apply.md
@@ -3,4 +3,7 @@ title: Apply
 layout: apply
 permalink: /participate/apply/
 ---
+<div class="alert alert-success" role="alert"><p><strong>Applications for our Spring 2015 term were due by January 27th and are now being reviewed. We expect to inform applicants by February 15th.</strong></p>
+<p>If you missed the deadline, we will continue accepting applications on a rolling basis until all slots have been filled.</p></div>
+
 Please answer all of the questions below. We may also contact you for a brief interview.


### PR DESCRIPTION
This branch removes the bright orange deadline reminder from the top nav, and modifies language on the Participate and Apply pages to note that the application for Spring deadline has passed, but we will continue to review applications on a rolling basis until all slots are filled.

## Nav

![screen shot 2015-01-28 at 12 06 04 pm](https://cloud.githubusercontent.com/assets/462020/5942615/a3b32394-a6e6-11e4-9f01-cfc638624ec3.png)

## Participate

![screen shot 2015-01-28 at 12 05 52 pm](https://cloud.githubusercontent.com/assets/462020/5942595/94844ae2-a6e6-11e4-8f0f-33180a3a1438.png)


## Apply

![screen shot 2015-01-28 at 12 05 42 pm](https://cloud.githubusercontent.com/assets/462020/5942607/9bb82de2-a6e6-11e4-8934-2023f2d7f7e0.png)
