### PR TITLE
fix 7 broken urls in /people/#filter=.summer-2016

### DIFF
--- a/_people/jonathan-leung.md
+++ b/_people/jonathan-leung.md
@@ -5,7 +5,7 @@ affiliation:
   role: Student
 twitter: 
 github: jonleung
-website: jonl.org 
+website: http://jonl.org 
 place: CA, USA
 ---
 Jonathan Leung loves creating. His mission in life is to enable others–as well as himself–to freely discover what they want in their own lives and enable them to relentlessly pursue that. More recently, Jonathan was doing this work as a former founder of Hack Club, a teacher at All Star Code and General Assembly, an early lead organizer ofPennApps, as the original creator of the Learners’ House, and hacking on fun project. Jonathan also loves yogaing, beatboxing, meditating, and creating social experiences that take people out of their standard social “scripts”. 

--- a/_people/krista-nordgren.md
+++ b/_people/krista-nordgren.md
@@ -5,7 +5,7 @@ affiliation:
   role: Student
 twitter: 
 github: 
-website: kristaannie.github.io/portfolio_page/
+website: http://kristaannie.github.io/portfolio_page/
 place: NC, USA
 ---
 Krista Anne lives in Durham, North Carolina where she owns a shop that showcases local artists and makers, and is a partner in a tiny web design and development firm. A former creative writing major, she’s interested in how to design narratives for dynamic screens. In her spare time, she walks in the woods with her tiny pitbull Jane, and is learning how to make beats with Maschine.  

--- a/_people/matt-visco.md
+++ b/_people/matt-visco.md
@@ -5,7 +5,7 @@ affiliation:
   role: Student
 twitter: 
 github: mattvisco
-website: mattvis.co
+website: http://mattvis.co
 place: CA
 ---
 Matt Visco is a creative technologist whose work focuses on design interactions aimed at exposing the hidden elements of daily life. His work manifests itself in both digital and physical objects that contain embedded behaviors and personalities. Matt holds a degree in computer science from University of Berkeley, California and is currently working as a freelance developer and designer in Oakland, California.

--- a/_people/max-fowler.md
+++ b/_people/max-fowler.md
@@ -5,7 +5,7 @@ affiliation:
   role: Student
 twitter: notplants
 github: mhfowler
-website: maxhfowler.net/portfolio/
+website: http://maxhfowler.net/portfolio/
 place: NYC, USA
 ---
 Max Fowler is a programmer and artist currently based in New York City. Some of his recent projects have explored the ways that we conceptualize space, expressive analysis of text message history and how to use a twitter bot to take out the trash. He is interested in using data visualization to explore subjectivity, generative poetry, and the ways we use technology to decide what to read. He also does freelance development and interaction design for startups. 

--- a/_people/meina-kalayeh.md
+++ b/_people/meina-kalayeh.md
@@ -5,7 +5,7 @@ affiliation:
   role: Student
 twitter: meinsta
 github: meinsta
-website: westpersia.com/projects
+website: http://westpersia.com/projects
 place: PA, USA
 ---
 Meina Kalayeh is a net artist and software engineer based out of Philadelphia. On the weekends, she makes vegan feasts and selects reggae/dancehall records with her boyfriend. 

--- a/_people/melanie-hoff.md
+++ b/_people/melanie-hoff.md
@@ -5,7 +5,7 @@ affiliation:
   role: Student
 twitter: melanie_hoff
 github: melaniehoff
-website: artdelicorp.com, Melanie-Hoff.com
+website: http://Melanie-Hoff.com
 place: NY, USA
 ---
 Melanie Hoff is an artist based in Brooklyn. Her practice investigates identity, visibility, and the ways in which appearances actively shape our interactions and consciousness. She uses technology and computation to play with systems that underlie contemporary society. She is interested in taking art out of the museum and into the processes of everyday life. Her previous work explored our relationship to technology and science by taking scientific processes and the aesthetics of the experiment as raw material. She studied sculpture, metalworking, and photography at Pratt institute and is currently a masters candidate at ITP. Her work has been featured on Radiolab, the Discovery Channel, and exhibited in galleries internationally.

--- a/_people/oren-shoham.md
+++ b/_people/oren-shoham.md
@@ -5,7 +5,7 @@ affiliation:
   role: Student
 twitter: 
 github: oshoham
-website: orenshoham.com
+website: http://orenshoham.com
 place: NY
 ---
 Oren Shoham is a Brooklyn-based programmer and musician. He is interested in using hardware and software to make things and experiences that play with sound, color, touch, and physical space. Previously, Oren studied computer science at Oberlin College, worked as a web developer for a while, and then participated in the Winter 2 2016 batch at the Recurse Center. 


### PR DESCRIPTION
`http://` was left out of 7 different links to personal websites. So if a url was listed say as `jonl.org`, it would redirect to `http://sfpc.io/people/jonl.org` (which does not exist) instead of `http://jonl.org`. I've added the http:// back into those 7 different urls which affects the personal websites of me (@jonleung), Krista, @mattvisco, @mhfowler, @meinsta, @melaniehoff, and @oshoham.

I think this is a recurring problem on the website (not under /people's webpages, but elsewhere).