### PR TITLE
Fix some social links

### DIFF
--- a/_people/ann-tbd.md
+++ b/_people/ann-tbd.md
@@ -5,8 +5,8 @@ affiliation:
   role: Student
 - class: Spring 2018
   role: TA
-instagram: https://www.instagram.com/ann_tbd 
-github: https://www.github.com/a-tbd
+instagram: ann_tbd
+github: a-tbd
 website: https://www.a-tbd.com
 place: NYC
 ---

--- a/_people/celine-katzman.md
+++ b/_people/celine-katzman.md
@@ -5,7 +5,7 @@ affiliation:
   role: TA
 - class: Fall 2018
   role: TA
-twitter: https://twitter.com/celinejade
+twitter: celinejade
 github:
 website: http://rhizome.org/profile/celinejade
 place: NYC

--- a/_people/patricio-gonzalez-vivo.md
+++ b/_people/patricio-gonzalez-vivo.md
@@ -3,8 +3,8 @@ title: Patricio Gonzalez Vivo
 affiliation:
 - class: Fall 2016
   role: Visitor
-twitter: https://twitter.com/patriciogv
-github: https://github.com/patriciogonzalezvivo
+twitter: patriciogv
+github: patriciogonzalezvivo
 website: http://patriciogonzalezvivo.com/
 place: Brooklyn, USA and Buenos Aires, Argentina
 ---

--- a/_people/riley-shaw.md
+++ b/_people/riley-shaw.md
@@ -3,10 +3,10 @@ title: Riley Shaw
 affiliation:
 - class: Spring 2018
   role: Student
-github: https://github.com/rileyjshaw
+github: rileyjshaw
 website: https://rileyjshaw.com
-twitter: https://twitter.com/rileyjshaw
-instagram: https://www.instagram.com/rileyjshaw/
+twitter: rileyjshaw
+instagram: rileyjshaw
 place: Toronto, Canada
 ---
 Riley hopes you’re having a good day so far. He just woke up and is deleting promo emails on his phone. Later, he will make some tea and do dishes. The faucet is a little drippy so he’ll fiddle with that. Riley has a background in design and electrical engineering and wrote software for Khan Academy before joining SFPC.


### PR DESCRIPTION
Listings with full social links (instead of just the profile / handle) linked to the wrong place, eg. https://github.com/https://www.github.com/a-tbd. This commit fixes the few listings with full links.