### PR TITLE
update some participate pages to use location and contact includes

### DIFF
--- a/_includes/contacts/sfpc.md
+++ b/_includes/contacts/sfpc.md
@@ -1,0 +1,1 @@
+Feel free to reach out to us if you have questions about the school: [info@sfpc.io](mailto:info@sfpc.io)

--- a/_includes/locations/westbeth.md
+++ b/_includes/locations/westbeth.md
@@ -1,0 +1,4 @@
+### Where is SFPC?
+We are located at 155 Bank Street, in the courtyard of the Westbeth Artists' Community in Manhattan's West Village, New York City.
+
+<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d3023.157285117621!2d-74.0114827845943!3d40.73656447932915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e6!4m3!3m2!1d40.736779899999995!2d-74.00924049999999!4m5!1s0x89c259eb003122d1%3A0xede8af6a55291528!2s155+Bank+St%2C+New+York%2C+NY+10014!3m2!1d40.7365645!2d-74.00929409999999!5e0!3m2!1sen!2sus!4v1466975848424" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>

--- a/_layouts/participate.html
+++ b/_layouts/participate.html
@@ -9,6 +9,16 @@ layout: default
 <div class="row">
 	<div class="col-md-8">
 		{{content}}
+		{% if page.location %}
+			{% assign location = 'locations/' | append: page.location | append: '.md' %}
+			{% capture location_include %}{% include {{ location }} %}{% endcapture %}
+			{{ location_include | markdownify }}
+		{% endif %}
+		{% if page.contact %}
+			{% assign contact = 'contacts/' | append: page.contact | append: '.md' %}
+			{% capture contact_include %}{% include {{ contact }} %}{% endcapture %}
+			{{ contact_include | markdownify }}
+		{% endif %}
 	</div>
 	<div id="testimonials" class="col-md-4">
 		{% for testimonial in site.data.testimonials %}

--- a/fall2016.md
+++ b/fall2016.md
@@ -1,6 +1,8 @@
 ---
 title: Fall 2016
 layout: participate
+location: westbeth
+contact: sfpc
 slides:
 
   - "/static/img/participate/door.jpg"
@@ -75,13 +77,6 @@ Occasionally, students have received support from cultural foundations or curren
 
 ### What is expected of me?
 
-Acceptance into the session is an invitation to join the SFPC community. Full-time participation during the ten weeks is mandatory. This also means you come prepared to all of the classes, do the homework, and engage with the community. We expect our students to be in the school between 10am~5pm, Monday to Friday. Read our <a href="/participate/"> Participate </a> page for more information.
+Acceptance into the session is an invitation to join the SFPC community. Full-time participation during the ten weeks is mandatory. This also means you come prepared to all of the classes, do the homework, and engage with the community. We expect our students to be in the school between 10am–5pm, Monday to Friday. Read our <a href="/participate/">Participate</a> page for more information.
 
-It’s also expected that you work openly – sharing what you learn along the way and collaborate with your peers. The success of the session for the group is dependent on engaged participation throughout the term. By participating you will be actively shaping an emerging culture of open source and transparent education. 
-
-### Where is SFPC?
-We are located in 155 Bank street, in the courtyard of the Westbeth Artists Community in the West Village, New York City.
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d3023.157285117621!2d-74.0114827845943!3d40.73656447932915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e6!4m3!3m2!1d40.736779899999995!2d-74.00924049999999!4m5!1s0x89c259eb003122d1%3A0xede8af6a55291528!2s155+Bank+St%2C+New+York%2C+NY+10014!3m2!1d40.7365645!2d-74.00929409999999!5e0!3m2!1sen!2sus!4v1466975848424" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
-
-Feel free to reach out to us if you have questions about the school: [info@sfpc.io](mailto:info@sfpc.io)
+It’s also expected that you work openly – sharing what you learn along the way and collaborating with your peers. The success of the session for the group is dependent on engaged participation throughout the term. By participating you will be actively shaping an emerging culture of open source and transparent education.

--- a/fall2017.md
+++ b/fall2017.md
@@ -1,6 +1,8 @@
 ---
 title: Fall 2017
 layout: participate
+location: westbeth
+contact: sfpc
 slides:
 
   - "/static/img/participate/bagels.jpg"
@@ -99,10 +101,3 @@ We are planning a Spring 2018 session from March 15 – May 31, 2018. We are als
 
 <div class="alert alert-success" role="alert"> <a href="https://docs.google.com/forms/d/e/1FAIpQLScLz8Vsrl7Xq5qUF9nDDNC1CP4DISY3Rxbq2SH0b_EoluL7_A/viewform">Apply to the Fall 2017 Session here.</a> Deadline for submissions, July 10th.
 </div>
-
-### Where is SFPC?
-We are located in 155 Bank street, in the courtyard of the Westbeth Artists Community in the West Village, New York City.
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d3023.157285117621!2d-74.0114827845943!3d40.73656447932915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e6!4m3!3m2!1d40.736779899999995!2d-74.00924049999999!4m5!1s0x89c259eb003122d1%3A0xede8af6a55291528!2s155+Bank+St%2C+New+York%2C+NY+10014!3m2!1d40.7365645!2d-74.00929409999999!5e0!3m2!1sen!2sus!4v1466975848424" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
-
-Feel free to reach out to us if you have questions about the school: [info@sfpc.io](mailto:info@sfpc.io)

--- a/fall2018.md
+++ b/fall2018.md
@@ -1,6 +1,8 @@
 ---
 title: fall 2018
 layout: participate
+location: westbeth
+contact: sfpc
 slides:
 
   - "/static/img/participate/bagels.jpg"
@@ -113,13 +115,4 @@ It’s also expected that you work openly – sharing what you learn along the w
 
 ### When is the next session?
 
-We are planning Spring 2019 session starting in February. We are also working on short Two-Weeks Intensive in Summer 2018 and Winter 2018. We also offer a variety of workshops and lectures. Please check our [blog](http://medium.com/sfpc) for the latest information.
- 
-  
-
-### Where is SFPC?
-We are located in 155 Bank street, in the courtyard of the Westbeth Artists Community in the West Village, New York City.
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d3023.157285117621!2d-74.0114827845943!3d40.73656447932915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e6!4m3!3m2!1d40.736779899999995!2d-74.00924049999999!4m5!1s0x89c259eb003122d1%3A0xede8af6a55291528!2s155+Bank+St%2C+New+York%2C+NY+10014!3m2!1d40.7365645!2d-74.00929409999999!5e0!3m2!1sen!2sus!4v1466975848424" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
-
-Feel free to reach out to us if you have questions about the school: [info@sfpc.io](mailto:info@sfpc.io)
+We are planning a Spring 2019 session starting in February. We are also working on short Two-Week Intensive sessions in Summer 2018 and Winter 2018. We also offer a variety of workshops and lectures. Please check our [blog](http://medium.com/sfpc) for the latest information.

--- a/fall2019.md
+++ b/fall2019.md
@@ -1,6 +1,8 @@
 ---
 title: Fall 2019
 layout: participate
+location: westbeth
+contact: sfpc
 slides:
 
   - "/static/img/participate/bagels.jpg"
@@ -113,10 +115,3 @@ Please note that if you apply for work study, we will consider your application 
 Acceptance into the session is an invitation to join the SFPC community. Full-time participation during the ten weeks is mandatory. This also means you come prepared to all of the classes, do the homework, and engage with the community. We expect our students to be in the school between 10am–5pm, Monday to Friday. Read our <a href="/participate/">Participate</a> page for more information.
 
 It’s also expected that you work openly — sharing what you learn along the way and collaborating with your peers. The success of the session for the group is dependent on engaged participation throughout the term. By participating you will be actively shaping an emerging culture of open source and transparent education.
-
-### Where is SFPC?
-We are located in 155 Bank Street, in the courtyard of the Westbeth Artists Community in the West Village, New York City.
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d3023.157285117621!2d-74.0114827845943!3d40.73656447932915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e6!4m3!3m2!1d40.736779899999995!2d-74.00924049999999!4m5!1s0x89c259eb003122d1%3A0xede8af6a55291528!2s155+Bank+St%2C+New+York%2C+NY+10014!3m2!1d40.7365645!2d-74.00929409999999!5e0!3m2!1sen!2sus!4v1466975848424" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
-
-Feel free to reach out to us if you have questions about the school: [info@sfpc.io](mailto:info@sfpc.io)

--- a/spring19bootcamp.md
+++ b/spring19bootcamp.md
@@ -1,6 +1,8 @@
 ---
 title: SFPC Bootcamp for New Coders - Spring '19
 layout: participate
+location: westbeth
+contact: sfpc
 slides:
 
   - "/static/img/bootcamp/bootcamp1.jpg"
@@ -86,17 +88,8 @@ We are committed to being fully transparent about how we make and spend money. I
 - B.Y.O.Laptop (Mac / PC / Linux)
 
 
-### Where is SFPC?
-We are located in 155 Bank street, in the courtyard of the Westbeth Artists Community in the West Village, New York City.
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d3023.157285117621!2d-74.0114827845943!3d40.73656447932915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e6!4m3!3m2!1d40.736779899999995!2d-74.00924049999999!4m5!1s0x89c259eb003122d1%3A0xede8af6a55291528!2s155+Bank+St%2C+New+York%2C+NY+10014!3m2!1d40.7365645!2d-74.00929409999999!5e0!3m2!1sen!2sus!4v1466975848424" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
-
-
-
 ### How do I apply?
 
 Applications for the Spring '19 New Coders Bootcamp - please [CLICK HERE](https://airtable.com/shr4DF0I48cpZB9Le) to submit your application. Deadline to apply, February, 16th 2019.
 
 We accept up to 17 students on a rolling basis. We will respond to your application within ~1 week of submission. Rolling admissions means there are fewer and fewer slots the longer you wait, so if you’re interested in the program get your application in early!
-
-Feel free to reach out to us if you have questions about the school: [info@sfpc.io](mailto:info@sfpc.io)

--- a/spring2018.md
+++ b/spring2018.md
@@ -1,6 +1,8 @@
 ---
 title: Spring 2018
 layout: participate
+location: westbeth
+contact: sfpc
 slides:
 
   - "/static/img/participate/bagels.jpg"
@@ -105,11 +107,3 @@ We are planning a Fall 2018 session starting in September. We are also working o
 
 <div class="alert alert-success" role="alert"> <a href="https://airtable.com/shrEm7HeqnrMYCMhc">Apply to the Spring 2018 Session here.</a> Deadline for submissions, extended to December 15, 2017
 </div>
-  
-
-### Where is SFPC?
-We are located in 155 Bank street, in the courtyard of the Westbeth Artists Community in the West Village, New York City.
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d3023.157285117621!2d-74.0114827845943!3d40.73656447932915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e6!4m3!3m2!1d40.736779899999995!2d-74.00924049999999!4m5!1s0x89c259eb003122d1%3A0xede8af6a55291528!2s155+Bank+St%2C+New+York%2C+NY+10014!3m2!1d40.7365645!2d-74.00929409999999!5e0!3m2!1sen!2sus!4v1466975848424" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
-
-Feel free to reach out to us if you have questions about the school: [info@sfpc.io](mailto:info@sfpc.io)

--- a/summer16short.md
+++ b/summer16short.md
@@ -1,6 +1,8 @@
 ---
-title: Code Subversions - Summer '16' 
+title: Code Subversions - Summer '16'
 layout: participate
+location: westbeth
+contact: sfpc
 slides:
 
   - "/static/img/participate/SFPC2-weekSummer.jpg"
@@ -75,17 +77,7 @@ We are committed to being fully transparent about how we make and spend money. I
 - We welcome students with a broad array of technical experiences--no coding experience is required, but a basic comfort level with technology is preferred.
 - B.Y.O.Laptop (Mac / PC / Linux)
 
-
-### Where is SFPC?
-We are located in 155 Bank street, in the courtyard of the Westbeth Artists Community in the West Village, New York City.
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d3023.157285117621!2d-74.0114827845943!3d40.73656447932915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e6!4m3!3m2!1d40.736779899999995!2d-74.00924049999999!4m5!1s0x89c259eb003122d1%3A0xede8af6a55291528!2s155+Bank+St%2C+New+York%2C+NY+10014!3m2!1d40.7365645!2d-74.00929409999999!5e0!3m2!1sen!2sus!4v1466975848424" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
-
-
-
 ### ~~How do I apply?~~
 **Sorry, applications are now closed**
 
 We accept up to 15 students on a rolling basis. We will respond to your application within ~1 week of submission. Rolling admissions means there are fewer and fewer slots the longer you wait, so if you’re interested in the program get your application in early!
-  
-Feel free to reach out to us if you have questions about the school: [info@sfpc.io](mailto:info@sfpc.io)


### PR DESCRIPTION

- Refactors some of the participate pages by extracting common content (location & contact info) as shared includes.
- Includes a few additional minor copy tweaks left over from #197

**How it works**

For any pages that use the `participate` layout, you can now add either or both of the following key/value pairs to the front matter of the page: 

```
location: westbeth
contact: sfpc
```

These includes then get added to the end of the page when it's generated.