### PR TITLE
add social includes, site metadata and update participate layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,11 @@
+short_title: SFPC
+title: School for Poetic Computation
+description: The School for Poetic Computation (SFPC), based in NYC, is a hybrid of school, artist residency and research group where students develop a deep curiosity of what it means to work poetically in computational media.
+image: https://sfpc.io/static/img/participate/sum2016_lunch.jpg
+social-network-links:
+  twitter: sfpc
+  instagram: sfpc_nyc
+  github: sfpc
 permalink: pretty
 plugins:
 - jekyll-redirect-from

--- a/_includes/social/opengraph.html
+++ b/_includes/social/opengraph.html
@@ -1,0 +1,4 @@
+<meta property="og:site_name" content="{{ default: site.title }}"/>
+<meta property="og:title" content="{{ site.short_title }} | {{ page.title | default: site.title }}" />
+<meta property="og:description" content="{{ page.description | default: site.description }}">
+<meta property="og:image" content="{{ page.image | default: site.image }}" />

--- a/_includes/social/twitter.html
+++ b/_includes/social/twitter.html
@@ -1,0 +1,5 @@
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@{{ site.social-network-links.twitter }}">
+<meta name="twitter:title" content="{{ site.short_title }} | {{ page.title | default: site.title }}">
+<meta name="twitter:description" content="{{ page.description | default: site.description }}">
+<meta name="twitter:image:src" content="{{ page.image | default: site.image }}">

--- a/_layouts/participate.html
+++ b/_layouts/participate.html
@@ -30,13 +30,6 @@ layout: default
 	</div>
 </div>
 
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:site" content="@sfpc">
-<meta name="twitter:title" content="Participate | School for Poetic Computation">
-<meta name="twitter:description" content="Learn more about School for Poetic Computation's (SFPC) upcoming session. SFPC is a hybrid of school, artist residency and research group where students develop a deep curiosity of what it means to work poetically in computational media.">
-<meta name="twitter:image:src" content="http://sfpc.io/static/img/participate/sum2016_lunch.jpg">
+{% include social/twitter.html %}
 
-<meta property="og:title" content="Participate | School for Poetic Computation" />
-<meta property="og:description" content="Learn more about School for Poetic Computation's (SFPC) upcoming session. SFPC is a hybrid of school, artist residency and research group where students develop a deep curiosity of what it means to work poetically in computational media." />
-<meta property="og:image" content="http://sfpc.io/static/img/participate/sum2016_lunch.jpg" />
-<meta property="og:site_name" content="School for Poetic Computation"/>
+{% include social/opengraph.html %}

--- a/fall2018.md
+++ b/fall2018.md
@@ -1,5 +1,5 @@
 ---
-title: fall 2018
+title: Fall 2018
 layout: participate
 location: westbeth
 contact: sfpc

--- a/fall2019.md
+++ b/fall2019.md
@@ -3,6 +3,7 @@ title: Fall 2019
 layout: participate
 location: westbeth
 contact: sfpc
+description: The School for Poetic Computation (SFPC) will host a ten week session in New York City from September 30th — December 6th, 2019. SFPC is a hybrid of school, artist residency and research group where students develop a deep curiosity of what it means to work poetically in computational media.
 slides:
 
   - "/static/img/participate/bagels.jpg"


### PR DESCRIPTION
- Add default ("evergreen") settings to site metadata for `title`, `description`, `image` 
- Add includes for twitter and opengraph meta tags
  - Use page metadata if defined, fall back to site metadata by default 
- Update the `participate` layout to use the includes
- Add a custom `description` to the front matter of the Fall 2019 page to override the evergreen one