### PR TITLE
Responsive  map on the faq page

### DIFF
--- a/_faqs/basics-and-administration.md
+++ b/_faqs/basics-and-administration.md
@@ -15,7 +15,8 @@ No. We do not issue formal degrees. By participating you will join a group of al
 
 We are located in 155 Bank Street, in the courtyard of the [Westbeth Artists Community](http://westbeth.org/) in the West Village, New York City.
 
-<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d3023.157285117621!2d-74.0114827845943!3d40.73656447932915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e6!4m3!3m2!1d40.736779899999995!2d-74.00924049999999!4m5!1s0x89c259eb003122d1%3A0xede8af6a55291528!2s155+Bank+St%2C+New+York%2C+NY+10014!3m2!1d40.7365645!2d-74.00929409999999!5e0!3m2!1sen!2sus!4v1466975848424" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
+<div style="position:relative; width: 100%; height: 300px;">
+<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d3023.157285117621!2d-74.0114827845943!3d40.73656447932915!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e6!4m3!3m2!1d40.736779899999995!2d-74.00924049999999!4m5!1s0x89c259eb003122d1%3A0xede8af6a55291528!2s155+Bank+St%2C+New+York%2C+NY+10014!3m2!1d40.7365645!2d-74.00929409999999!5e0!3m2!1sen!2sus!4v1466975848424" width= "100%" height="100%" frameborder="0" style="border:0" allowfullscreen></iframe></div>
 
 ### How can I support SFPC?
 


### PR DESCRIPTION
Changed from fixed width map to responsive map on the faq page. Tested on
safari, chrome, and firefox.

Might be worth making a reusable layout//component for google maps embeds?

resolves #236 